### PR TITLE
Fix Bowser MCP typo

### DIFF
--- a/browser-tools/README.md
+++ b/browser-tools/README.md
@@ -29,7 +29,7 @@
 }
 ```
 
-- Bowser MCP
+- Browser MCP
 ```json
    "browsermcp": {
       "command": "npx",


### PR DESCRIPTION
## Summary
- fix a typo in `browser-tools/README.md`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_683fd18f39c8832cb72b03512eeb8783